### PR TITLE
fix(algorithms): centralize fail-open logic in common handler and apply to all limiters

### DIFF
--- a/examples/inmemory/main.go
+++ b/examples/inmemory/main.go
@@ -12,7 +12,7 @@ import (
 // main runs a simple demonstration of the rate limiter.
 func main() {
 	limiter, _ := gorl.New(core.Config{
-		Strategy: core.FixedWindow,
+		Strategy: core.TokenBucket,
 		KeyBy:    core.KeyByIP,
 		Limit:    3,
 		Window:   10 * time.Second,


### PR DESCRIPTION
fix(algorithms): centralize fail-open logic and apply to all limiters

- Introduce algorithms/common.go with failOpenHandler to DRY up error handling  
- Update FixedWindow, SlidingWindow and LeakyBucket to use the shared helper  
- Remove duplicated fail-open blocks in each Allow()  
- Ensure inmem and main respect the failOpen flag
