### PR TITLE
fix(algorithms): centralize fail-open logic in common handler and apply to all limiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 coverage
 coverage.html
 
+# backup & temp files
+*~
+*.un~
+
 
 # Build / binary folders
 /bin/

--- a/examples/redis/main.go
+++ b/examples/redis/main.go
@@ -12,11 +12,12 @@ import (
 // main runs a simple demonstration of the rate limiter using a Redis backend.
 func main() {
 	limiter, err := gorl.New(core.Config{
-		Strategy: core.FixedWindow,
+		Strategy: core.TokenBucket,
 		KeyBy:    core.KeyByAPIKey,
 		Limit:    4,
 		Window:   10 * time.Second,
 		RedisURL: "redis://localhost:6379/0",
+		FailOpen: true,
 	})
 	if err != nil {
 		panic(err)

--- a/internal/algorithms/common.go
+++ b/internal/algorithms/common.go
@@ -1,0 +1,29 @@
+// algorithms/common.go
+package algorithms
+
+import (
+	"time"
+
+	"github.com/AliRizaAynaci/gorl/core"
+)
+
+// failOpenHandler centralizes fail-open logic.
+//   - start: timestamp when Allow began (for latency metrics)
+//   - err: storage/algorithm error
+//   - failOpen: cfg.FailOpen flag
+//   - m: metrics collector
+//
+// Returns (allowed, retErr, done):
+//   - done=true: caller should return immediately with (allowed, retErr)
+//   - done=false: no error, continue normal flow
+func failOpenHandler(start time.Time, err error, failOpen bool, m core.MetricsCollector) (bool, error, bool) {
+	if err == nil {
+		return false, nil, false
+	}
+	if failOpen {
+		m.ObserveLatency(time.Since(start))
+		m.IncAllow()
+		return true, nil, true
+	}
+	return false, err, true
+}


### PR DESCRIPTION
fix(algorithms): centralize fail-open logic in common handler and apply to all limiters

- Introduce algorithms/common.go with failOpenHandler to DRY up error handling
- Update FixedWindow, SlidingWindow and LeakyBucket to use the shared helper
- Remove duplicated fail-open blocks in each Allow()
- Ensure inmem and main respect the failOpen flag
