### PR TITLE
fix(sliding-window): guard the in-memory path against concurrent over-admission

### DIFF
--- a/internal/algorithms/sliding_window.go
+++ b/internal/algorithms/sliding_window.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/AliRizaAynaci/gorl/v2/core"
@@ -19,6 +20,7 @@ type SlidingWindowLimiter struct {
 	stateTTL time.Duration
 	store    storage.Storage
 	prefix   string
+	mu       sync.Mutex
 	metrics  core.MetricsCollector
 	failOpen bool
 }
@@ -43,6 +45,13 @@ func (s *SlidingWindowLimiter) Allow(ctx context.Context, key string) (core.Resu
 		return s.allowRedis(ctx, start, runner, key)
 	}
 
+	// The generic path reads the counters, decides, and only then increments,
+	// which is not atomic across the store's Get/Incr calls. Serialize it like
+	// TokenBucketLimiter and LeakyBucketLimiter do so concurrent requests for the
+	// same key cannot both pass the check and admit over the limit. The redis
+	// path stays lock-free because its Lua script is already atomic.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.allowGeneric(ctx, start, key)
 }
 

--- a/internal/algorithms/sliding_window_test.go
+++ b/internal/algorithms/sliding_window_test.go
@@ -3,6 +3,8 @@ package algorithms
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -545,5 +547,42 @@ func BenchmarkSlidingWindow_MultiKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("user-%d", i%1000)
 		limiter.Allow(ctx, key)
+	}
+}
+
+// TestSlidingWindow_ConcurrentDoesNotExceedLimit is a regression test for the
+// missing lock on the generic (in-memory) path. Many goroutines hit the same
+// key inside a single window; with the read-check-then-Incr sequence unguarded,
+// they could all pass the check and admit well over the limit (and race on the
+// store). Run with -race to also catch the data race.
+func TestSlidingWindow_ConcurrentDoesNotExceedLimit(t *testing.T) {
+	store := inmem.NewInMemoryStore()
+	defer store.Close()
+
+	const limit = 50
+	limiter := NewSlidingWindowLimiter(core.Config{
+		// A long window so no rollover happens during the test: every request
+		// lands in the same window, so at most `limit` may be admitted.
+		Limit: limit, Window: time.Minute, Metrics: &core.NoopMetrics{},
+	}, store)
+	ctx := context.Background()
+
+	const goroutines = 500
+	var allowed int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			res, err := limiter.Allow(ctx, "user-1")
+			if err == nil && res.Allowed {
+				atomic.AddInt64(&allowed, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if allowed > limit {
+		t.Fatalf("sliding window admitted %d concurrent requests, over the limit of %d", allowed, limit)
 	}
 }


### PR DESCRIPTION
### Problem

`SlidingWindowLimiter.allowGeneric` (the in-memory / generic Storage path) reads the counters, decides, and only then increments:

```go
prevCount, _ := s.store.Get(ctx, prevKey)
currCount, _ := s.store.Get(ctx, currKey)
slidingCount := prevCount*(1-ratio) + currCount
allowed := slidingCount < float64(s.limit)   // check on the values just read
if allowed {
    _, err := s.store.Incr(ctx, currKey, s.stateTTL)  // separate step
}
```

`Allow` dispatches straight to `allowGeneric` with no lock, and the struct has no mutex. So two goroutines hitting the same key can both read the same counters, both evaluate `allowed = true`, and both `Incr`, admitting more than `limit` requests in the window (and racing on the store). For a limiter used in HTTP middleware, concurrent requests for the same client key are the normal case.

The sibling limiters already avoid this:
- `TokenBucketLimiter` and `LeakyBucketLimiter` hold a `sync.Mutex` around their read-compute-write path.
- `FixedWindowLimiter` is lock-free but safe because it does a single atomic `Incr` and checks the returned value, so there is no read-then-increment gap.

`SlidingWindowLimiter` is the only one that both lacks a lock and checks a value it read separately from the increment.

### Fix

Add a `sync.Mutex` to `SlidingWindowLimiter` and hold it around the generic path in `Allow`, matching `TokenBucketLimiter` / `LeakyBucketLimiter`. The redis path is left lock-free since its Lua script is already atomic.

Adds `TestSlidingWindow_ConcurrentDoesNotExceedLimit`: 500 goroutines against one key inside a single (1 minute) window, asserting no more than `limit` are admitted. It over-admits (and trips `-race`) without the lock and passes with it.
