### PR TITLE
docs: document lock sharding and refresh benchmark numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Recommended entry points:
 - [Choose an Algorithm](docs/concepts/algorithms.md)
 - [Keys and Resources](docs/concepts/keys-and-resources.md)
 - [System Overview](docs/architecture/system-overview.md)
+- [Concurrency and Lock Sharding](docs/architecture/concurrency.md)
 - [Distributed Semantics](docs/architecture/distributed-semantics.md)
 - [Middleware Guide](docs/guides/middleware.md)
 - [Redis in Production](docs/guides/redis-production.md)
@@ -389,44 +390,77 @@ func main() {
 
 ## Benchmarks
 
-Benchmarks below are averages of 3 runs on Apple M4 using:
+Every figure is the **median of 10 samples** summarized with `benchstat`, measured
+on Apple M4 with Go 1.26.0 against the current release. Redis figures used Redis
+7.4.10 in a local `redis:7-alpine` container. `±` is the sample spread.
 
 ```bash
-go test ./internal/algorithms -run=^$ -bench=. -benchmem -benchtime=1s -count=3
+GORL_REDIS_URL=redis://127.0.0.1:6379/0 \
+go test ./internal/algorithms \
+  -run=^$ \
+  -bench='^Benchmark(Redis_)?(FixedWindow|SlidingWindow|TokenBucket|LeakyBucket)_' \
+  -benchmem \
+  -benchtime=1s \
+  -count=10 | tee results.txt
+
+benchstat results.txt
 ```
 
-Redis results were measured against a local `redis:7-alpine` container and
-reflect the Lua-backed atomic execution path.
+### Scenarios
+
+| Scenario | What it measures |
+| --- | --- |
+| Single key | One key, one goroutine, request allowed. |
+| Multi key | 1024 distinct keys, one goroutine, request allowed. |
+| Denied | Limit already exhausted, so the rejection path runs. |
+| Parallel, single key | Every goroutine competes for the same key. |
+| Parallel, multi key | Goroutines spread across 1024 distinct keys. |
 
 ### In-Memory Backend
 
-| Algorithm      | Single Key (ns/op, B/op, allocs)     | Multi Key (ns/op, B/op, allocs)      |
-| -------------- | ------------------------------------ | ------------------------------------ |
-| Fixed Window   | 217.2 ns/op, 64 B/op, 4 allocs/op    | 268.8 ns/op, 86 B/op, 5 allocs/op    |
-| Sliding Window | 394.8 ns/op, 168 B/op, 9 allocs/op   | 504.2 ns/op, 182 B/op, 10 allocs/op  |
-| Token Bucket   | 467.6 ns/op, 272 B/op, 12 allocs/op  | 546.0 ns/op, 300 B/op, 13 allocs/op  |
-| Leaky Bucket   | 474.7 ns/op, 272 B/op, 12 allocs/op  | 570.0 ns/op, 286 B/op, 13 allocs/op  |
+Time per operation (ns/op):
+
+| Algorithm | Single key | Multi key | Denied | Parallel, single key | Parallel, multi key |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Fixed Window | 209.3 ± 1% | 221.8 ± 0% | 211.2 ± 4% | 204.2 ± 4% | **67.3 ± 4%** |
+| Sliding Window | 524.2 ± 13% | 497.9 ± 15% | 399.6 ± 2% | 604.8 ± 2% | **265.8 ± 4%** |
+| Token Bucket | 484.3 ± 3% | 548.0 ± 1% | 492.9 ± 1% | 703.5 ± 3% | **367.2 ± 6%** |
+| Leaky Bucket | 467.2 ± 2% | 520.8 ± 2% | 456.8 ± 1% | 616.8 ± 8% | **328.1 ± 7%** |
+
+Allocations are constant per algorithm across every scenario: Fixed Window
+4 allocs/op (64–72 B/op), Sliding Window 9 allocs/op (168–192 B/op), Token Bucket
+and Leaky Bucket 12 allocs/op (272–288 B/op).
+
+The two parallel columns are the interesting pair. `Parallel, single key` is
+slower than the sequential case because one key must stay serialized, while
+`Parallel, multi key` is the fastest column because unrelated keys hold different
+lock shards and run concurrently. See
+[Concurrency and lock sharding](docs/architecture/concurrency.md)
+for how that works and what it changed.
 
 ### Redis Backend
 
-| Algorithm      | Single Key (ns/op, B/op, allocs)        | Multi Key (ns/op, B/op, allocs)         |
-| -------------- | --------------------------------------- | --------------------------------------- |
-| Fixed Window   | 100797.0 ns/op, 416 B/op, 17 allocs/op | 103031.7 ns/op, 452 B/op, 17 allocs/op |
-| Sliding Window | 106871.3 ns/op, 912 B/op, 32 allocs/op | 118876.3 ns/op, 970.3 B/op, 33 allocs/op |
-| Token Bucket   | 107571.0 ns/op, 800 B/op, 28 allocs/op | 108520.0 ns/op, 861 B/op, 29 allocs/op |
-| Leaky Bucket   | 103766.0 ns/op, 800 B/op, 28 allocs/op | 111682.3 ns/op, 859 B/op, 29 allocs/op |
+Time per operation (µs/op):
 
-### Redis: Before Lua vs After Lua
+| Algorithm | Single key | Multi key | Denied | Parallel, single key | Parallel, multi key |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Fixed Window | 95.2 ± 2% | 95.6 ± 7% | 95.4 ± 6% | 37.5 ± 19% | 44.8 ± 12% |
+| Sliding Window | 123.9 ± 11% | 130.5 ± 23% | 124.1 ± 2% | 48.9 ± 7% | 48.3 ± 3% |
+| Token Bucket | 118.2 ± 4% | 119.9 ± 4% | 119.6 ± 2% | 49.2 ± 8% | 48.2 ± 5% |
+| Leaky Bucket | 118.0 ± 7% | 121.0 ± 4% | 118.8 ± 3% | 47.0 ± 3% | 48.4 ± 3% |
 
-| Algorithm      | Single Key                             | Multi Key                              |
-| -------------- | -------------------------------------- | -------------------------------------- |
-| Fixed Window   | `178022.0 -> 100797.0 ns/op` `43.4%` faster | `186592.7 -> 103031.7 ns/op` `44.8%` faster |
-| Sliding Window | `457973.7 -> 106871.3 ns/op` `76.7%` faster | `462304.7 -> 118876.3 ns/op` `74.3%` faster |
-| Token Bucket   | `374951.7 -> 107571.0 ns/op` `71.3%` faster | `399340.7 -> 108520.0 ns/op` `72.8%` faster |
-| Leaky Bucket   | `386675.0 -> 103766.0 ns/op` `73.2%` faster | `470074.0 -> 111682.3 ns/op` `76.2%` faster |
+Allocations per operation: Fixed Window 16–17 allocs (456–476 B), Sliding Window
+31–32 allocs (~1.03–1.08 KiB), Token Bucket 26–27 allocs (880–916 B), Leaky
+Bucket 27 allocs (888–924 B).
 
-These comparisons use the same benchmark command, the same local Redis
-container setup, and 3-run averages before and after the Lua migration.
+Redis numbers are dominated by network round-trip time, not by GoRL. That is why
+the parallel columns are roughly twice as fast: concurrent goroutines overlap
+their round trips. Compare Redis figures only against each other on the same host
+and network path, never against the in-memory table.
+
+These are comparative figures from one machine, not latency guarantees. See
+[Benchmarking methodology](docs/contributing/benchmarking.md) for the control
+group and A/B comparison rules behind any performance claim in this project.
 
 ## Storage Backends
 

--- a/docs/architecture/concurrency.md
+++ b/docs/architecture/concurrency.md
@@ -1,0 +1,179 @@
+<div class="gorl-lock-page" markdown>
+
+<section class="gorl-lock-hero">
+<div class="gorl-lock-hero__copy">
+<p class="gorl-lock-kicker">v2.2.1 · internal concurrency</p>
+<h1>One key should not stop another.</h1>
+<p>
+GoRL keeps same-key state transitions serialized while letting unrelated
+in-process keys advance through separate lock lanes. The public API,
+rate-limit semantics, and Redis state format stay unchanged. In the
+measured parallel multi-key workload, median time per operation fell by
+61.1% to 66.7%, depending on the algorithm.
+</p>
+</div>
+<div class="gorl-lock-release-rail" aria-label="Concurrency implementation release path">
+<div class="gorl-lock-release">
+<span class="gorl-lock-release__tag">v2.2.0</span>
+<strong>Mixed baseline</strong>
+<span>Token and leaky buckets used one lock; sliding window still had a concurrency gap.</span>
+</div>
+<div class="gorl-lock-release gorl-lock-release--checkpoint">
+<span class="gorl-lock-release__tag">safety checkpoint</span>
+<strong>Correct first</strong>
+<span>Sliding window gained serialization so concurrent requests could not over-admit.</span>
+</div>
+<div class="gorl-lock-release gorl-lock-release--current">
+<span class="gorl-lock-release__tag">v2.2.1</span>
+<strong>Correct and concurrent</strong>
+<span>All three generic stateful limiters use the same bounded sharded-lock model.</span>
+</div>
+</div>
+</section>
+
+## From one gate to independent lanes
+
+The safety baseline placed one mutex around each limiter's complete generic
+state transition. That protected correctness, but a slow operation for
+`tenant-a` also held up unrelated work for `tenant-b` and `tenant-c`.
+
+<div class="gorl-lock-board">
+<section class="gorl-lock-panel gorl-lock-panel--before" aria-label="Before: unrelated keys wait at one limiter-wide mutex">
+<header>
+<div>
+<span class="gorl-lock-panel__eyebrow">Before · safety baseline</span>
+<p class="gorl-lock-panel__name">One limiter, one gate</p>
+</div>
+<span class="gorl-lock-panel__state">serialized</span>
+</header>
+<div class="gorl-lock-diagram gorl-lock-diagram--single">
+<div class="gorl-lock-requests" aria-label="Incoming keys">
+<code>tenant-a</code>
+<code>tenant-b</code>
+<code>tenant-c</code>
+</div>
+<div class="gorl-lock-paths" aria-hidden="true"><span></span><span></span><span></span></div>
+<div class="gorl-lock-gate gorl-lock-gate--single"><span>one<br>mutex</span></div>
+<div class="gorl-lock-outcomes">
+<span class="gorl-lock-outcome gorl-lock-outcome--run">running</span>
+<span class="gorl-lock-outcome gorl-lock-outcome--wait">waiting</span>
+<span class="gorl-lock-outcome gorl-lock-outcome--wait">waiting</span>
+</div>
+</div>
+<p>Correct, but independent keys share the same contention point.</p>
+</section>
+<section class="gorl-lock-panel gorl-lock-panel--after" aria-label="After: unrelated keys advance through separate lock shards">
+<header>
+<div>
+<span class="gorl-lock-panel__eyebrow">After · v2.2.1</span>
+<p class="gorl-lock-panel__name">One limiter, 256 lanes</p>
+</div>
+<span class="gorl-lock-panel__state">concurrent</span>
+</header>
+<div class="gorl-lock-diagram gorl-lock-diagram--sharded">
+<div class="gorl-lock-requests" aria-label="Incoming keys">
+<code>tenant-a</code>
+<code>tenant-b</code>
+<code>tenant-c</code>
+</div>
+<div class="gorl-lock-paths" aria-hidden="true">
+<span><i></i></span><span><i></i></span><span><i></i></span>
+</div>
+<div class="gorl-lock-gates" aria-label="Illustrative shard assignments">
+<span>shard 042</span>
+<span>shard 187</span>
+<span>shard 091</span>
+</div>
+<div class="gorl-lock-outcomes">
+<span class="gorl-lock-outcome gorl-lock-outcome--run">running</span>
+<span class="gorl-lock-outcome gorl-lock-outcome--run">running</span>
+<span class="gorl-lock-outcome gorl-lock-outcome--run">running</span>
+</div>
+</div>
+<p>Shard numbers are illustrative; each limiter receives a process-local random hash seed.</p>
+</section>
+</div>
+
+## How a key chooses its lock
+
+<div class="gorl-lock-formula" aria-label="Key-to-lock-shard selection flow">
+<div><span>input</span><code>tenant-a:user-123</code></div>
+<b aria-hidden="true">→</b>
+<div><span>hash</span><code>maphash.String(seed, key)</code></div>
+<b aria-hidden="true">→</b>
+<div><span>mask</span><code>hash &amp; 255</code></div>
+<b aria-hidden="true">→</b>
+<div><span>lock</span><code>mutex[index]</code></div>
+</div>
+
+The locker creates one random `maphash` seed when the generic limiter is
+constructed. For that limiter and process lifetime, the same key produces the
+same hash and therefore the same index.
+
+`256` is a power of two, so `hash & 255` selects the lower eight bits and is
+equivalent to `hash % 256`. Two different keys can land on the same index. That
+collision is safe: those keys briefly serialize, while the rate-limit result
+remains correct.
+
+This design deliberately avoids a mutex map keyed by caller input. Memory stays
+bounded at about 2 KB per generic stateful limiter and does not grow with key
+cardinality. Redis-backed limiters do not allocate these locks because their
+Lua transitions are already atomic.
+
+## What remains invariant
+
+| Invariant | Guarantee |
+| --- | --- |
+| Same key, one transition | Concurrent calls for one key still execute their multi-step state update serially. |
+| Collisions stay safe | A shard collision can reduce parallelism, but it cannot admit requests above the configured limit. |
+| Redis bypasses the locker | The bundled Redis backend continues to execute each decision in an atomic Lua script. |
+| No public contract changes | Constructors, configuration, result metadata, middleware, and storage keys remain compatible. |
+
+## Measured effect
+
+Apple M4, Go 1.26.0, in-memory store. Ten interleaved samples per side compared
+with `benchstat`; each cell is the median with its spread. `~` means the
+difference is not statistically significant. The full procedure, including why
+the runs are interleaved, is in
+[Benchmarking methodology](../contributing/benchmarking.md).
+
+| Benchmark | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Fixed window, parallel single key *(control)* | 229.8 ns ± 8% | 227.9 ns ± 10% | ~ (p=0.986) |
+| Fixed window, parallel multi-key *(control)* | 95.8 ns ± 38% | 101.0 ns ± 37% | ~ (p=0.780) |
+| Sliding window, parallel single key | 707.3 ns ± 24% | 749.8 ns ± 36% | ~ (p=0.353) |
+| Sliding window, parallel multi-key | 787.6 ns ± 23% | 262.4 ns ± 24% | **−66.7%** (p=0.000) |
+| Token bucket, parallel single key | 745.4 ns ± 21% | 758.6 ns ± 23% | ~ (p=0.971) |
+| Token bucket, parallel multi-key | 823.1 ns ± 44% | 320.3 ns ± 21% | **−61.1%** (p=0.000) |
+| Leaky bucket, parallel single key | 715.9 ns ± 17% | 734.8 ns ± 20% | ~ (p=0.853) |
+| Leaky bucket, parallel multi-key | 813.4 ns ± 24% | 315.4 ns ± 23% | **−61.2%** (p=0.000) |
+
+Bytes and allocations per operation are byte-identical on both sides for every
+benchmark, so the change costs no additional garbage.
+
+Three rows carry the argument:
+
+- **The control rows do not move.** The fixed window takes no limiter-level lock,
+  so this change cannot affect it. Its flat result is what makes the other rows
+  trustworthy; a control that moves means the machine drifted, not that the code
+  improved.
+- **Single-key rows are `~`.** One key must stay serialized for correctness, and
+  hashing the key to a shard costs nothing measurable.
+- **Multi-key rows drop to roughly a third of their original cost.** This is the
+  case the change targets: independent keys no longer queue behind each other.
+
+Treat these figures as comparative evidence on one machine, not as a latency
+guarantee for another machine or workload.
+
+## Upgrade to v2.2.1
+
+!!! tip "Drop-in patch release"
+    ```bash
+    go get github.com/AliRizaAynaci/gorl/v2@v2.2.1
+    ```
+
+    No migration is required. Applications do not need new options, different
+    keys, or middleware changes. Run the normal test suite for your service and
+    deploy the patch release through the same process used for `v2.2.0`.
+
+</div>

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -53,5 +53,8 @@ sequenceDiagram
   middleware packages provide a default key extractor when one is omitted.
 - `FailOpen` and `FailClose` behavior is enforced inside the algorithm layer.
 - The in-memory store handles TTL cleanup internally with a background GC loop.
+- Generic sliding-window, token-bucket, and leaky-bucket transitions use
+  [key-sharded synchronization](./concurrency.md) so unrelated keys can advance
+  independently while same-key updates remain serialized.
 - Redis-backed behavior depends on the storage backend plus the algorithm's
   state transition strategy.

--- a/docs/concepts/algorithms.md
+++ b/docs/concepts/algorithms.md
@@ -93,9 +93,13 @@ GoRL does not provide that behavior.
 | Path | Concurrency behavior |
 | --- | --- |
 | In-memory fixed window | Atomic counter operations in the bundled store |
-| Other generic/in-memory strategies | Limiter-level synchronization around multi-step state changes |
+| Other generic/in-memory strategies | Key-sharded synchronization around multi-step state changes |
 | Bundled Redis backend | Algorithm-specific atomic Lua execution |
 | Custom `storage.Storage` | The interface operations apply, but bundled Redis script guarantees do not automatically transfer |
+
+Read [Concurrency and lock sharding](../architecture/concurrency.md) for the
+same-key correctness model, shard selection, memory trade-off, and measured
+parallel behavior.
 
 Read [Distributed semantics](../architecture/distributed-semantics.md) before
 using a custom store or shared deployment.

--- a/docs/contributing/benchmarking.md
+++ b/docs/contributing/benchmarking.md
@@ -1,0 +1,119 @@
+# Benchmarking Methodology
+
+This page defines how GoRL benchmark numbers are produced. Every performance
+figure published in the README or in `docs/` follows this procedure, so a reader
+can reproduce it and a reviewer can challenge it.
+
+## Tooling
+
+Comparisons use [`benchstat`][benchstat], the standard Go tool for summarizing
+benchmark samples:
+
+```bash
+go install golang.org/x/perf/cmd/benchstat@latest
+```
+
+`benchstat` reports the median of the samples together with the spread, and
+marks differences that are not statistically significant as `~`. Do not compute
+averages by hand, and do not quote a single run.
+
+[benchstat]: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
+
+## Reporting rules
+
+- Report the **median** of at least 10 samples. One run is noise.
+- Always name the machine, the Go version, and the exact command.
+- For an A/B claim, name the **two git refs** that were compared.
+- If `benchstat` prints `~`, the honest wording is "no measurable change", not
+  a percentage.
+- Treat every figure as comparative evidence on one machine, never as a latency
+  guarantee.
+
+## The control group rule
+
+At least one benchmark in every comparison must be one the change **cannot**
+affect. `BenchmarkFixedWindow_*` is the standing control for anything touching
+the generic limiter path: the fixed window uses the store's atomic `Incr` and
+takes no limiter-level lock.
+
+If the control moves between the two sides, the machine drifted (thermal
+throttling, background load) and the run is invalid. This is not hypothetical:
+an uninterleaved run on an Apple M4 showed the lock-free fixed window
+"regressing" by 70%, which was entirely machine state.
+
+## The interleaving rule
+
+Do not collect all `before` samples and then all `after` samples. Alternate them
+so drift hits both sides equally:
+
+```bash
+for round in $(seq 1 10); do
+  (cd "$BEFORE_TREE" && go test ./internal/algorithms \
+    -run=^$ -bench="$PATTERN" -benchmem -benchtime=1s -count=1 >> before.txt)
+  go test ./internal/algorithms \
+    -run=^$ -bench="$PATTERN" -benchmem -benchtime=1s -count=1 >> after.txt
+done
+
+benchstat before.txt after.txt
+```
+
+Build `$BEFORE_TREE` with `git worktree add` at the baseline ref. When the
+baseline predates a benchmark you want to compare, copy the current benchmark
+harness (`benchmark_helpers_test.go`) into it so both sides run identical
+measurement code and only the implementation differs.
+
+## In-memory benchmarks
+
+```bash
+go test ./internal/algorithms \
+  -run=^$ \
+  -bench='^Benchmark(FixedWindow|SlidingWindow|TokenBucket|LeakyBucket)_' \
+  -benchmem \
+  -benchtime=1s \
+  -count=10
+```
+
+Benchmark shapes and what each one answers:
+
+| Suffix | Question it answers |
+| --- | --- |
+| `_SingleKey` | Sequential cost of one decision. |
+| `_MultiKey` | Sequential cost across 1024 distinct keys. |
+| `_DeniedSingleKey` | Cost of the rejection path, which skips the write. |
+| `_ParallelSingleKey` | Contention cost when every goroutine shares one key. |
+| `_ParallelMultiKey` | Whether independent keys can use available CPU. |
+
+The parallel pair is the meaningful one for concurrency work. `ParallelSingleKey`
+is the price of correctness — one key must stay serialized — so it is expected
+to stay flat. `ParallelMultiKey` is where a concurrency change should show up.
+
+## Redis benchmarks
+
+Redis benchmarks need a reachable server and are addressed by the `Redis_`
+prefix:
+
+```bash
+docker run --rm -d -p 6379:6379 --name gorl-bench redis:7-alpine
+
+GORL_REDIS_URL=redis://127.0.0.1:6379/0 \
+go test ./internal/algorithms \
+  -run=^$ \
+  -bench='^BenchmarkRedis_' \
+  -benchmem \
+  -benchtime=1s \
+  -count=10
+
+docker rm -f gorl-bench
+```
+
+Record the Redis server version alongside the results. Redis figures are
+dominated by round-trip latency, so they are only comparable within one host and
+one network path; never compare them against the in-memory table.
+
+## What CI measures
+
+The `Run algorithm benchmarks` step in `.github/workflows/ci.yml` executes the
+suite with `-count=3` and uploads `benchmark-results.txt` as an artifact. That
+artifact is a **trend signal**, not a comparison basis: it is a shared runner
+with no control over neighbors, and `-count=3` is below the reporting threshold
+above. Published numbers come from a local run following this page.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -340,9 +340,434 @@ body {
   margin: 0;
 }
 
+.gorl-lock-page {
+  --gorl-lock-coral-soft: rgba(255, 86, 56, 0.09);
+  --gorl-lock-cyan-soft: rgba(55, 199, 233, 0.1);
+  --gorl-lock-panel: rgba(255, 255, 255, 0.76);
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-page {
+  --gorl-lock-coral-soft: rgba(255, 111, 84, 0.12);
+  --gorl-lock-cyan-soft: rgba(55, 199, 233, 0.12);
+  --gorl-lock-panel: rgba(12, 27, 36, 0.84);
+}
+
+.gorl-lock-page .gorl-lock-hero {
+  background-color: var(--gorl-mist);
+  background-image: linear-gradient(rgba(8, 125, 154, 0.075) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(8, 125, 154, 0.075) 1px, transparent 1px);
+  background-size: 24px 24px;
+  border: 1px solid rgba(8, 125, 154, 0.2);
+  border-left: 0.32rem solid var(--gorl-coral);
+  border-radius: 0.85rem;
+  margin: 0.5rem 0 3rem;
+  overflow: hidden;
+  padding: clamp(1.35rem, 4vw, 3rem);
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-page .gorl-lock-hero {
+  background-color: #0b1a23;
+  background-image: linear-gradient(rgba(55, 199, 233, 0.065) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(55, 199, 233, 0.065) 1px, transparent 1px);
+  border-color: rgba(55, 199, 233, 0.2);
+  border-left-color: var(--gorl-coral);
+}
+
+.gorl-lock-kicker,
+.gorl-lock-panel__eyebrow,
+.gorl-lock-release__tag,
+.gorl-lock-formula span {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.gorl-lock-kicker {
+  color: var(--gorl-cyan-deep);
+  margin: 0 0 0.7rem;
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-kicker {
+  color: #65d8ef;
+}
+
+.gorl-lock-page .gorl-lock-hero h1 {
+  color: var(--gorl-night);
+  font-size: clamp(2.25rem, 7vw, 4.8rem);
+  letter-spacing: -0.06em;
+  line-height: 0.96;
+  margin: 0;
+  max-width: 12ch;
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-page .gorl-lock-hero h1 {
+  color: #f3fcfd;
+}
+
+.gorl-lock-hero__copy > p:last-child {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.98rem;
+  line-height: 1.65;
+  margin: 1rem 0 0;
+  max-width: 48rem;
+}
+
+.gorl-lock-release-rail {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2.6rem;
+}
+
+.gorl-lock-release {
+  border-top: 2px solid rgba(20, 35, 46, 0.22);
+  padding: 1.05rem 1rem 0 0;
+  position: relative;
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-release {
+  border-top-color: rgba(164, 225, 237, 0.24);
+}
+
+.gorl-lock-release::before {
+  background: var(--gorl-ink);
+  border: 3px solid var(--gorl-mist);
+  border-radius: 50%;
+  content: "";
+  height: 0.7rem;
+  left: 0;
+  position: absolute;
+  top: -0.45rem;
+  width: 0.7rem;
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-release::before {
+  background: #9adfee;
+  border-color: #0b1a23;
+}
+
+.gorl-lock-release--checkpoint::before {
+  background: var(--gorl-coral);
+}
+
+.gorl-lock-release--current {
+  border-top-color: var(--gorl-cyan-deep);
+}
+
+.gorl-lock-release--current::before {
+  background: var(--gorl-cyan);
+  box-shadow: 0 0 0 0.28rem rgba(55, 199, 233, 0.16);
+}
+
+.gorl-lock-release__tag {
+  color: var(--gorl-cyan-deep);
+  display: block;
+  margin-bottom: 0.45rem;
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-release__tag {
+  color: #65d8ef;
+}
+
+.gorl-lock-release strong,
+.gorl-lock-release > span:last-child {
+  display: block;
+}
+
+.gorl-lock-release strong {
+  color: var(--gorl-ink);
+  font-size: 0.82rem;
+  margin-bottom: 0.28rem;
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-release strong {
+  color: #effbfc;
+}
+
+.gorl-lock-release > span:last-child {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.68rem;
+  line-height: 1.45;
+  max-width: 15rem;
+}
+
+.gorl-lock-board {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 1.4rem 0 2.8rem;
+}
+
+.gorl-lock-panel {
+  background: var(--gorl-lock-panel);
+  border: 1px solid var(--gorl-line);
+  border-radius: 0.8rem;
+  overflow: hidden;
+  padding: clamp(1rem, 2.5vw, 1.4rem);
+}
+
+.gorl-lock-panel--before {
+  box-shadow: inset 0 0.2rem 0 var(--gorl-coral);
+}
+
+.gorl-lock-panel--after {
+  box-shadow: inset 0 0.2rem 0 var(--gorl-cyan);
+}
+
+.gorl-lock-panel > header {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: space-between;
+}
+
+.gorl-lock-panel > header > div {
+  min-width: 0;
+}
+
+.gorl-lock-panel__eyebrow {
+  color: var(--md-default-fg-color--light);
+}
+
+.gorl-lock-page .gorl-lock-panel__name {
+  color: var(--gorl-ink);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0.28rem 0 0;
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-page .gorl-lock-panel__name {
+  color: #effbfc;
+}
+
+/* The hero title is a display element, not a section anchor. */
+.gorl-lock-page .gorl-lock-hero h1 .headerlink {
+  display: none;
+}
+
+.gorl-lock-panel__state {
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--gorl-coral);
+  flex: 0 0 auto;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.58rem;
+  padding: 0.24rem 0.45rem;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.gorl-lock-panel--after .gorl-lock-panel__state {
+  color: var(--gorl-cyan-deep);
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-panel--after .gorl-lock-panel__state {
+  color: #67dbf2;
+}
+
+.gorl-lock-diagram {
+  align-items: stretch;
+  display: grid;
+  gap: 0.4rem;
+  /* The panel is only ~14.3rem wide at Material's default grid, so fixed tracks
+     used to overflow and get clipped by the panel's overflow: hidden. Every
+     track is minmax(0, ...) so it can shrink instead, and the label tracks are
+     sized to their longest string ("shard 042", "tenant-a", "running") to leave
+     the widest possible lane for the animated flow line. */
+  grid-template-columns:
+    minmax(0, 3.2rem) minmax(1.4rem, 1fr) minmax(0, 3.3rem) minmax(0, 2.5rem);
+  margin: 1.4rem 0 1rem;
+  min-height: 7.6rem;
+}
+
+.gorl-lock-requests,
+.gorl-lock-paths,
+.gorl-lock-gates,
+.gorl-lock-outcomes {
+  display: grid;
+  gap: 0.48rem;
+  grid-template-rows: repeat(3, 1fr);
+  min-width: 0;
+}
+
+.gorl-lock-gate {
+  min-width: 0;
+}
+
+.gorl-lock-requests code {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--gorl-ink);
+  display: flex;
+  font-size: 0.62rem;
+  min-width: 0;
+  padding: 0;
+  white-space: nowrap;
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-requests code {
+  color: #dff7fb;
+}
+
+.gorl-lock-paths span {
+  align-self: center;
+  background: var(--gorl-line);
+  display: block;
+  height: 1px;
+  position: relative;
+}
+
+.gorl-lock-panel--before .gorl-lock-paths span:nth-child(n + 2) {
+  background-image: repeating-linear-gradient(90deg, var(--gorl-coral) 0 3px, transparent 3px 7px);
+}
+
+.gorl-lock-gate,
+.gorl-lock-gates span {
+  align-items: center;
+  border-radius: 0.38rem;
+  display: flex;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.57rem;
+  font-weight: 600;
+  justify-content: center;
+  line-height: 1.3;
+  min-width: 0;
+  padding: 0 0.15rem;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.gorl-lock-gate--single {
+  background: var(--gorl-coral);
+  color: #fff;
+}
+
+.gorl-lock-gates span {
+  background: var(--gorl-lock-cyan-soft);
+  border: 1px solid rgba(8, 125, 154, 0.32);
+  color: var(--gorl-cyan-deep);
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-gates span {
+  border-color: rgba(89, 214, 240, 0.32);
+  color: #85e4f6;
+}
+
+.gorl-lock-outcome {
+  align-items: center;
+  display: flex;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.54rem;
+  justify-content: flex-end;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.gorl-lock-outcome--run {
+  color: var(--gorl-cyan-deep);
+}
+
+.gorl-lock-outcome--wait {
+  color: var(--gorl-coral);
+}
+
+[data-md-color-scheme="slate"] .gorl-lock-outcome--run {
+  color: #72deF3;
+}
+
+.gorl-lock-panel--after .gorl-lock-paths i {
+  animation: gorl-lock-flow 2.8s ease-in-out infinite;
+  background: var(--gorl-cyan);
+  border-radius: 50%;
+  box-shadow: 0 0 0 0.2rem rgba(55, 199, 233, 0.12);
+  height: 0.38rem;
+  left: 0;
+  position: absolute;
+  top: -0.19rem;
+  width: 0.38rem;
+}
+
+.gorl-lock-panel--after .gorl-lock-paths span:nth-child(2) i {
+  animation-delay: -0.9s;
+}
+
+.gorl-lock-panel--after .gorl-lock-paths span:nth-child(3) i {
+  animation-delay: -1.8s;
+}
+
+@keyframes gorl-lock-flow {
+  0% { left: 0; opacity: 0; }
+  15% { opacity: 1; }
+  82% { left: calc(100% - 0.38rem); opacity: 1; }
+  100% { left: calc(100% - 0.38rem); opacity: 0; }
+}
+
+.gorl-lock-panel > p {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.gorl-lock-formula {
+  align-items: stretch;
+  background: var(--gorl-night);
+  border: 1px solid rgba(55, 199, 233, 0.24);
+  border-radius: 0.72rem;
+  color: #dff9fd;
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: minmax(7rem, 1fr) auto minmax(9rem, 1.4fr) auto minmax(6rem, 0.8fr) auto minmax(6rem, 0.8fr);
+  margin: 1.2rem 0 1.5rem;
+  padding: 1rem;
+}
+
+.gorl-lock-formula > div {
+  min-width: 0;
+}
+
+.gorl-lock-formula span {
+  color: rgba(199, 243, 251, 0.48);
+  display: block;
+  margin-bottom: 0.32rem;
+}
+
+.gorl-lock-formula code {
+  background: transparent;
+  border: 0;
+  color: #bceff8;
+  display: block;
+  font-size: 0.62rem;
+  overflow-wrap: anywhere;
+  padding: 0;
+}
+
+.gorl-lock-formula b {
+  align-self: center;
+  color: var(--gorl-coral);
+  font-family: "IBM Plex Mono", monospace;
+}
+
 @media screen and (max-width: 76.1875em) {
   .gorl-hero {
     grid-template-columns: 1fr;
+  }
+
+  .gorl-lock-board {
+    grid-template-columns: 1fr;
+  }
+
+  .gorl-lock-formula {
+    grid-template-columns: 1fr;
+  }
+
+  .gorl-lock-formula b {
+    justify-self: center;
+    transform: rotate(90deg);
   }
 }
 
@@ -365,10 +790,56 @@ body {
   .gorl-strip {
     gap: 1rem;
   }
+
+  .gorl-lock-page .gorl-lock-hero {
+    border-radius: 0.68rem;
+    margin-inline: -0.4rem;
+    padding: 1.2rem;
+  }
+
+  .gorl-lock-release-rail {
+    grid-template-columns: 1fr;
+  }
+
+  .gorl-lock-release {
+    border-left: 2px solid rgba(20, 35, 46, 0.22);
+    border-top: 0;
+    padding: 0 0 1.2rem 1rem;
+  }
+
+  [data-md-color-scheme="slate"] .gorl-lock-release {
+    border-left-color: rgba(164, 225, 237, 0.24);
+  }
+
+  .gorl-lock-release::before {
+    left: -0.45rem;
+    top: 0;
+  }
+
+  .gorl-lock-release--current {
+    border-left-color: var(--gorl-cyan-deep);
+    padding-bottom: 0;
+  }
+
+  .gorl-lock-diagram {
+    gap: 0.3rem;
+    grid-template-columns:
+      minmax(0, 2.7rem) minmax(1rem, 1fr) minmax(0, 2.9rem) minmax(0, 2.2rem);
+  }
+
+  .gorl-lock-requests code,
+  .gorl-lock-gate,
+  .gorl-lock-gates span,
+  .gorl-lock-outcome {
+    font-size: 0.49rem;
+  }
+
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .gorl-card {
+  .gorl-card,
+  .gorl-lock-panel--after .gorl-lock-paths i {
+    animation: none;
     transition: none;
   }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
   - Architecture:
       - System overview: architecture/system-overview.md
       - Request lifecycle: architecture/request-lifecycle.md
+      - Concurrency and lock sharding: architecture/concurrency.md
       - Distributed semantics: architecture/distributed-semantics.md
       - Package map: architecture/package-map.md
   - API Reference:
@@ -135,3 +136,4 @@ nav:
   - Contributing:
       - Contribute: contributing/index.md
       - Documentation style: contributing/docs-style.md
+      - Benchmarking methodology: contributing/benchmarking.md


### PR DESCRIPTION
## Summary
- Add a Concurrency and lock sharding page explaining the v2.2.1 key-lock sharding change (#30): the prior single-mutex baseline, how a key maps to one of 256 shards, the invariants it preserves, and the measured before/after effect with a control-group benchmark and p-values.
- Add a Benchmarking methodology page: benchstat over 10+ interleaved samples, a control-group benchmark, and the exact reproduction commands.
- Refresh the README Benchmarks section with current-release medians (benchstat) across every scenario, including the parallel shapes that v2.2.1 actually improved.
- Cross-link the new pages from the request lifecycle and algorithms concept pages, and wire them into mkdocs nav.

Depends on v2.2.1 being tagged, since the concurrency page's upgrade snippet references it directly.
